### PR TITLE
fix(salesforce): shorten isSandbox field description

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce/index.ts
@@ -31,7 +31,7 @@ const destination: DestinationDefinition<Settings> = {
       isSandbox: {
         label: 'Sandbox Instance',
         description:
-          'Enable to authenticate into a sandbox instance. You can log in to a sandbox by appending the sandbox name to your Salesforce username. For example, if a username for a production org is user@acme.com and the sandbox is named test, the username to log in to the sandbox is user@acme.com.test. If you are already authenticated, please disconnect and reconnect with your sandbox username.',
+          'Enable to authenticate into a Salesforce sandbox. Use your username with the sandbox name appended, e.g. user@acme.com.test.',
         type: 'boolean',
         default: false
       },


### PR DESCRIPTION
The Sandbox Instance toggle description was a full paragraph copied from Salesforce docs. Shortened to one line.

**Before:**
> Enable to authenticate into a sandbox instance. You can log in to a sandbox by appending the sandbox name to your Salesforce username. For example, if a username for a production org is user@acme.com and the sandbox is named test, the username to log in to the sandbox is user@acme.com.test. If you are already authenticated, please disconnect and reconnect with your sandbox username.

**After:**
> Enable to authenticate into a Salesforce sandbox. Use your username with the sandbox name appended, e.g. user@acme.com.test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change to the Salesforce destination auth field description with no behavioral impact.
> 
> **Overview**
> Updates the Salesforce (Actions) destination `isSandbox` authentication field description to a shorter, clearer one-line instruction for sandbox login (username with sandbox suffix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f66a1065d37e7d3b63d85bc573b866659ca9af8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->