### PR TITLE
fix: pin pull_request_target checkout to base ref

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # SECURITY: Always pin to the base branch ref when using pull_request_target.
+          # Never checkout github.head_ref — that is attacker-controlled on public repos.
+          # See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
       - name: Compute Labels
         id: compute-labels


### PR DESCRIPTION
## What

Pins the `actions/checkout` step in `label-prs.yml` to `github.event.pull_request.base.sha` instead of relying on the implicit default.

## Why

`pull_request_target` workflows run with repo secrets and write permissions. Without an explicit `ref`, `actions/checkout` defaults to the base branch, which is safe — but implicit and fragile. If someone ever adds `ref: ${{ github.head_ref }}`, a malicious fork PR could execute arbitrary code with the `GH_PAT_MEMBER_AND_PULL_REQUEST_READONLY` PAT (which has `members:read` on the org).

This makes the security boundary explicit. The `compute-labels.js` script only uses the GitHub API (not local files), so checking out the base ref is functionally identical.

**Ref:** https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the GitHub Actions checkout ref (and adds security comments), with no runtime code changes; should only affect which commit is checked out during labeling.
> 
> **Overview**
> Makes the `label-prs.yml` `pull_request_target` workflow explicitly checkout `github.event.pull_request.base.sha` (instead of relying on implicit defaults) and adds inline security guidance to avoid checking out attacker-controlled PR refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9461228e55d310a40be7637df36cca30ea0875d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->